### PR TITLE
Rewrite calendar views to use local data context

### DIFF
--- a/components/CalendarYear.jsx
+++ b/components/CalendarYear.jsx
@@ -1,38 +1,28 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { auth, db } from "@/lib/firebase";
-import { onAuthStateChanged } from "firebase/auth";
-import {
-  collection,
-  onSnapshot,
-  orderBy,
-  query,
-  where,
-  Timestamp,
-} from "firebase/firestore";
 
-function toDate(val) {
-  if (!val) return null;
-  if (val instanceof Date) return val;
-  if (val.toDate) return val.toDate();
-  return new Date(val);
-}
+import { useLifehubData } from "@/lib/data-context";
 
-function startOfYear(date) {
-  const d = new Date(date.getFullYear(), 0, 1);
-  d.setHours(0, 0, 0, 0);
-  return d;
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function ensureDate(value) {
+  if (!value) return null;
+  return value instanceof Date ? value : new Date(value);
 }
-function endOfYear(d) {
-  const x = new Date(d.getFullYear(), 11, 31);
-  x.setHours(23, 59, 59, 999);
-  return x;
-}
-function monthLabel(i) {
-  return new Date(2000, i, 1).toLocaleString(undefined, { month: "long" });
-}
-/* ------------------------------------------------------- */
 
 export default function CalendarYear({
   calendarFilter = "all",
@@ -40,136 +30,184 @@ export default function CalendarYear({
   search = "",
   onCalendarsDiscovered = () => {},
 }) {
-  const [user, setUser] = useState(null);
-  const [events, setEvents] = useState([]);
-  const [todos, setTodos] = useState([]);
+  const { events, todos } = useLifehubData();
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+
+  const year = currentDate.getFullYear();
+  const searchQuery = search.trim().toLowerCase();
+  const selected = useMemo(
+    () => (selectedCalendarIds.length ? new Set(selectedCalendarIds) : null),
+    [selectedCalendarIds]
+  );
+
+  const filteredEvents = useMemo(() => {
+    return events
+      .map((event) => ({
+        ...event,
+        start: ensureDate(event.start),
+        end: ensureDate(event.end),
+      }))
+      .filter((event) => {
+        if (!event.start || event.start.getFullYear() !== year) return false;
+        const calendarId = event.calendarId || "main";
+        if (calendarFilter !== "all" && calendarId !== calendarFilter) return false;
+        if (selected && selected.size > 0 && !selected.has(calendarId)) return false;
+        if (searchQuery) {
+          const haystack = `${event.summary || ""} ${event.description || ""} ${
+            event.location || ""
+          }`.toLowerCase();
+          if (!haystack.includes(searchQuery)) return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.start - b.start);
+  }, [events, calendarFilter, selected, searchQuery, year]);
+
+  const filteredTodos = useMemo(() => {
+    return todos
+      .map((todo) => ({
+        ...todo,
+        due: ensureDate(todo.due),
+      }))
+      .filter((todo) => {
+        if (!todo.due || todo.due.getFullYear() !== year) return false;
+        const calendarId = todo.calendarId || "main";
+        if (calendarFilter !== "all" && calendarId !== calendarFilter) return false;
+        if (selected && selected.size > 0 && !selected.has(calendarId)) return false;
+        if (searchQuery && !todo.text?.toLowerCase().includes(searchQuery)) return false;
+        return true;
+      })
+      .sort((a, b) => a.due - b.due);
+  }, [todos, calendarFilter, selected, searchQuery, year]);
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => setUser(u || null));
-    return () => unsub();
-  }, []);
-
-  const yStart = startOfYear(currentDate);
-  const yEnd = endOfYear(currentDate);
-
-  // events in year
-  useEffect(() => {
-    if (!user) return;
-    const qEv = query(
-      collection(db, "users", user.uid, "events"),
-      where("start", ">=", Timestamp.fromDate(yStart)),
-      where("start", "<=", Timestamp.fromDate(yEnd)),
-      orderBy("start", "asc")
-    );
-    const unsub = onSnapshot(qEv, (snap) => {
-      const list = [];
-      snap.forEach((d) => {
-        const data = d.data() || {};
-        list.push({
-          id: d.id,
-          title: data.summary || data.title || "(no title)",
-          start: toDate(data.start),
-          calendarId: data.calendarId || "main",
-        });
-      });
-      setEvents(list);
-    });
-    return () => unsub();
-  }, [user, yStart.getTime(), yEnd.getTime()]);
-
-  // todos (we’ll just count/peek by month if due is set)
-  useEffect(() => {
-    if (!user) return;
-    const qTd = query(
-      collection(db, "users", user.uid, "todos"),
-      orderBy("createdAt", "desc")
-    );
-    const unsub = onSnapshot(qTd, (snap) => {
-      const list = [];
-      snap.forEach((d) => {
-        const data = d.data() || {};
-        list.push({
-          id: d.id,
-          title: data.text || data.title || "(untitled task)",
-          due: toDate(data.due),
-          calendarId: data.calendarId || "main",
-          completed: !!data.completed,
-        });
-      });
-      setTodos(list);
-    });
-    return () => unsub();
-  }, [user]);
-
-  const activeCalendars = useMemo(() => {
-    if (calendarFilter === "all") return null;
-    if (calendarFilter !== "main" && selectedCalendarIds?.length) {
-      return new Set(selectedCalendarIds);
-    }
-    return new Set([calendarFilter]);
-  }, [calendarFilter, selectedCalendarIds]);
+    const calendars = new Set();
+    filteredEvents.forEach((event) => calendars.add(event.calendarId || "main"));
+    filteredTodos.forEach((todo) => calendars.add(todo.calendarId || "main"));
+    const discovered = Array.from(calendars)
+      .filter((id) => id && id !== "main")
+      .map((id) => ({ id, name: id }));
+    onCalendarsDiscovered(discovered);
+  }, [filteredEvents, filteredTodos, onCalendarsDiscovered]);
 
   const grouped = useMemo(() => {
-    const g = Array.from({ length: 12 }, () => ({ events: [], todos: [] }));
-
-    const inCal = (cid) => !activeCalendars || activeCalendars.has(cid || "main");
-
-    events.forEach((ev) => {
-      if (!ev.start) return;
-      if (!inCal(ev.calendarId)) return;
-      const m = ev.start.getMonth();
-      g[m].events.push(ev);
+    const buckets = Array.from({ length: 12 }, () => ({ events: [], todos: [] }));
+    filteredEvents.forEach((event) => {
+      if (!event.start) return;
+      buckets[event.start.getMonth()].events.push(event);
     });
-
-    todos.forEach((td) => {
-      if (!td.due) return;
-      if (!inCal(td.calendarId)) return;
-      const m = td.due.getMonth();
-      g[m].todos.push(td);
+    filteredTodos.forEach((todo) => {
+      if (!todo.due) return;
+      buckets[todo.due.getMonth()].todos.push(todo);
     });
+    return buckets;
+  }, [filteredEvents, filteredTodos]);
 
-    return g;
-  }, [events, todos, activeCalendars]);
+  const goYear = (delta) => {
+    setCurrentDate((current) => new Date(current.getFullYear() + delta, 0, 1));
+  };
+
+  const summaryCount = grouped.reduce(
+    (acc, bucket) => acc + bucket.events.length + bucket.todos.length,
+    0
+  );
+
+  if (summaryCount === 0) {
+    return (
+      <div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={() => goYear(-1)}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-1 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-200"
+          >
+            Previous year
+          </button>
+          <div className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+            {year}
+          </div>
+          <button
+            type="button"
+            onClick={() => goYear(1)}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-1 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-200"
+          >
+            Next year
+          </button>
+        </div>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          No events or tasks match the selected filters for this year.
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl p-4">
-      <div className="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-3">
-        {currentDate.getFullYear()}
+    <div className="space-y-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => goYear(-1)}
+          className="rounded-lg border border-gray-300 bg-white px-3 py-1 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-200"
+        >
+          Previous year
+        </button>
+        <div className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+          {year}
+        </div>
+        <button
+          type="button"
+          onClick={() => goYear(1)}
+          className="rounded-lg border border-gray-300 bg-white px-3 py-1 text-sm text-gray-600 transition hover:bg-gray-100 dark:border-neutral-700 dark:bg-neutral-900 dark:text-gray-200"
+        >
+          Next year
+        </button>
       </div>
 
-      <div className="grid grid-cols-3 gap-4">
-        {grouped.map((bucket, i) => (
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {grouped.map((bucket, index) => (
           <div
-            key={i}
-            className="rounded-xl border border-gray-200 dark:border-gray-700 p-3 bg-gray-50 dark:bg-gray-800"
+            key={MONTH_NAMES[index]}
+            className="rounded-xl border border-gray-200 bg-gray-50 p-3 dark:border-neutral-800 dark:bg-neutral-950"
           >
-            <div className="text-sm font-semibold text-gray-800 dark:text-gray-100 mb-2">
-              {monthLabel(i)}
+            <div className="mb-2 text-sm font-semibold text-gray-800 dark:text-gray-100">
+              {MONTH_NAMES[index]}
             </div>
-
-            <div className="text-xs text-gray-600 dark:text-gray-300 mb-1">
+            <div className="mb-2 text-xs text-gray-600 dark:text-gray-300">
               {bucket.events.length} events • {bucket.todos.length} tasks
             </div>
-
-            {/* Peek list (up to 5 items) */}
-            <ul className="space-y-1">
-              {[...bucket.events.slice(0, 3), ...bucket.todos.slice(0, 2)].map((it) => (
+            <ul className="space-y-1 text-xs">
+              {bucket.events.slice(0, 2).map((event) => (
                 <li
-                  key={`${"completed" in it ? "td" : "ev"}-${it.id}`}
-                  className="truncate text-xs px-2 py-1 rounded-md bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-100"
-                  title={it.title}
+                  key={`event-${event.id}`}
+                  className="truncate rounded-md bg-indigo-50 px-2 py-1 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-100"
+                  title={event.summary || "(no title)"}
                 >
-                  {"completed" in it ? "✓ " : ""}
-                  {it.title}
+                  <div className="font-medium">
+                    {event.summary || "(no title)"}
+                  </div>
+                  <div className="text-[10px] text-indigo-500">
+                    {event.start?.toLocaleDateString?.()}
+                  </div>
                 </li>
               ))}
+              {bucket.todos.slice(0, 2).map((todo) => (
+                <li
+                  key={`todo-${todo.id}`}
+                  className="truncate rounded-md bg-emerald-50 px-2 py-1 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-100"
+                  title={todo.text}
+                >
+                  <div className="font-medium">✓ {todo.text}</div>
+                  <div className="text-[10px] text-emerald-500">
+                    Due {todo.due?.toLocaleDateString?.()}
+                  </div>
+                </li>
+              ))}
+              {bucket.events.length + bucket.todos.length > 4 && (
+                <li className="text-[10px] text-gray-500 dark:text-gray-400">
+                  +{bucket.events.length + bucket.todos.length - 4} more
+                </li>
+              )}
             </ul>
-
-            {bucket.events.length + bucket.todos.length > 5 && (
-              <div className="mt-1 text-[11px] text-gray-600 dark:text-gray-300">
-                +{bucket.events.length + bucket.todos.length - 5} more
-              </div>
-            )}
           </div>
         ))}
       </div>

--- a/components/TodoList.jsx
+++ b/components/TodoList.jsx
@@ -1,134 +1,169 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { auth, db } from "@/lib/firebase";
-import { onAuthStateChanged } from "firebase/auth";
-import {
-  addDoc,
-  collection,
-  deleteDoc,
-  doc,
-  onSnapshot,
-  orderBy,
-  query,
-  serverTimestamp,
-  updateDoc,
-} from "firebase/firestore";
+import { useMemo, useState } from "react";
+
+import { useLifehubData } from "@/lib/data-context";
+
+const FALLBACK_CALENDAR_NAME = "Personal";
 
 export default function TodoList({
   calendarFilter = "all",
   search = "",
   selectedCalendarIds = [],
 }) {
-  const [user, setUser] = useState(null);
-  const [todos, setTodos] = useState([]);
+  const { calendars, todos, addTodo, toggleTodo, removeTodo } = useLifehubData();
   const [text, setText] = useState("");
-  const [calendarId, setCalendarId] = useState("main");
-  const [due, setDue] = useState("");
   const [saving, setSaving] = useState(false);
 
-  // auth
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => setUser(u || null));
-    return () => unsub();
-  }, []);
+  const calendarNameById = useMemo(() => {
+    const map = new Map();
+    calendars.forEach((calendar) => {
+      if (calendar?.id) {
+        map.set(calendar.id, calendar.name || calendar.id);
+      }
+    });
+    if (!map.has("main")) {
+      map.set("main", FALLBACK_CALENDAR_NAME);
+    }
+    return map;
+  }, [calendars]);
 
-  // load todos
-  useEffect(() => {
-    if (!user) return;
-    const q = query(
-      collection(db, "users", user.uid, "todos"),
-      orderBy("createdAt", "desc")
-    );
-    const unsub = onSnapshot(q, (snap) => {
-      const list = [];
-      snap.forEach((d) => {
-        const data = d.data() || {};
-        list.push({
-          id: d.id,
-          text: data.text || "(untitled task)",
-          calendarId: data.calendarId || "main",
-          due: data.due?.toDate?.() || null,
-          done: !!data.done,
-        });
+  const derivedCalendarId = useMemo(() => {
+    if (calendarFilter !== "all") return calendarFilter;
+    if (selectedCalendarIds.length === 1) return selectedCalendarIds[0];
+    return "main";
+  }, [calendarFilter, selectedCalendarIds]);
+
+  const filteredTodos = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const selected = selectedCalendarIds.length
+      ? new Set(selectedCalendarIds)
+      : null;
+
+    return todos
+      .filter((todo) => {
+        const calendarId = todo.calendarId || "main";
+        if (calendarFilter !== "all" && calendarId !== calendarFilter) return false;
+        if (selected && selected.size > 0 && !selected.has(calendarId)) return false;
+        if (query && !todo.text?.toLowerCase().includes(query)) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const aTime = a.createdAt ? a.createdAt.getTime() : 0;
+        const bTime = b.createdAt ? b.createdAt.getTime() : 0;
+        return bTime - aTime;
       });
-      setTodos(list);
-    });
-    return () => unsub();
-  }, [user]);
+  }, [
+    todos,
+    calendarFilter,
+    search,
+    selectedCalendarIds,
+  ]);
 
-  const addTodo = async (e) => {
-    e.preventDefault();
-    const t = text.trim();
-    if (!user || !t) return;
-    await addDoc(collection(db, "users", user.uid, "todos"), {
-      text: t,
-      done: false,
-      createdAt: serverTimestamp(),
-    });
-    setText("");
+  const add = (event) => {
+    event.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    try {
+      setSaving(true);
+      addTodo({ text: trimmed, calendarId: derivedCalendarId });
+      setText("");
+    } finally {
+      setSaving(false);
+    }
   };
 
-  const toggleDone = async (id, done) => {
-    if (!user) return;
-    await updateDoc(doc(db, "users", user.uid, "todos", id), { done: !done });
-  };
+  const toggle = (id) => toggleTodo(id);
+  const remove = (id) => removeTodo(id);
 
-  const removeTodo = async (id) => {
-    if (!user) return;
-    await deleteDoc(doc(db, "users", user.uid, "todos", id));
-  };
-
-  if (!user) {
+  if (filteredTodos.length === 0 && !text) {
     return (
-      <p className="text-gray-600 text-sm">
-        Sign in to create your to-dos.
-      </p>
+      <div className="space-y-4">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Add your first task to get started.
+        </p>
+        <form onSubmit={add} className="flex gap-2">
+          <input
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+            placeholder="Add a to-do…"
+            className="flex-1 rounded-lg border border-gray-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={saving}
+            className="h-10 rounded-lg bg-indigo-600 px-4 text-sm font-semibold text-white disabled:opacity-60"
+          >
+            {saving ? "Adding…" : "Add"}
+          </button>
+        </form>
+      </div>
     );
   }
 
   return (
-    <div className="w-full max-w-md space-y-4">
-      <form onSubmit={addTodo} className="flex gap-2">
+    <div className="space-y-4">
+      <form onSubmit={add} className="flex gap-2">
         <input
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(event) => setText(event.target.value)}
           placeholder="Add a to-do…"
-          className="flex-1 rounded-lg border px-3 py-2"
+          className="flex-1 rounded-lg border border-gray-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-3 py-2 text-sm"
         />
         <button
           type="submit"
           disabled={saving}
-          className="h-10 px-4 rounded-lg bg-blue-600 text-white text-sm font-semibold disabled:opacity-60"
+          className="h-10 rounded-lg bg-indigo-600 px-4 text-sm font-semibold text-white disabled:opacity-60"
         >
           {saving ? "Adding…" : "Add"}
         </button>
       </form>
 
       <ul className="space-y-2">
-  {todos.map((t) => (
-    <li
-      key={t.id}
-      className="flex items-center justify-between rounded-lg border bg-gray-50 px-4 py-3 hover:bg-gray-100 transition"
-    >
-      <button
-        onClick={() => toggleDone(t.id, t.done)}
-        className={`text-left flex-1 ${
-          t.done ? "line-through text-gray-400" : "text-gray-800"
-        }`}
-      >
-        {t.text}
-      </button>
-      <button
-        onClick={() => removeTodo(t.id)}
-        className="text-red-500 text-sm hover:underline"
-      >
-        Delete
-      </button>
-    </li>
-  ))}
-</ul>
+        {filteredTodos.map((todo) => {
+          const calendarId = todo.calendarId || "main";
+          const calendarName = calendarNameById.get(calendarId) || calendarId;
+          const dueLabel = todo.due
+            ? todo.due.toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              })
+            : null;
 
+          return (
+            <li
+              key={todo.id}
+              className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-800 shadow-sm transition hover:bg-gray-100 dark:border-neutral-800 dark:bg-neutral-900 dark:text-gray-100 dark:hover:bg-neutral-800"
+            >
+              <button
+                type="button"
+                onClick={() => toggle(todo.id)}
+                className={`flex-1 text-left ${
+                  todo.done
+                    ? "text-gray-400 line-through"
+                    : "text-gray-800 dark:text-gray-50"
+                }`}
+              >
+                <div className="font-medium">{todo.text}</div>
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="rounded-full bg-white px-2 py-0.5 dark:bg-neutral-800">
+                    {calendarName}
+                  </span>
+                  {dueLabel && <span>Due {dueLabel}</span>}
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => remove(todo.id)}
+                className="text-xs font-semibold text-red-500 hover:underline"
+              >
+                Delete
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }

--- a/components/Upcoming.jsx
+++ b/components/Upcoming.jsx
@@ -1,104 +1,97 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { auth, db } from "@/lib/firebase";
-import { onAuthStateChanged } from "firebase/auth";
-import {
-  collection,
-  onSnapshot,
-  orderBy,
-  query,
-  where,
-  Timestamp,
-} from "firebase/firestore";
+import { useMemo } from "react";
+
+import { useLifehubData } from "@/lib/data-context";
+
+const MAX_RESULTS = 50;
+
+function formatRange(event) {
+  if (event.allDay) return "All day";
+  const startLabel = event.start.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const endLabel = event.end
+    ? event.end.toLocaleTimeString(undefined, {
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : null;
+  return endLabel ? `${startLabel} – ${endLabel}` : startLabel;
+}
 
 export default function Upcoming({
   calendarFilter = "all",
   search = "",
   selectedCalendarIds = [],
 }) {
-  const [user, setUser] = useState(null);
-  const [events, setEvents] = useState([]);
+  const { events } = useLifehubData();
 
-  useEffect(() => {
-    const unsub = onAuthStateChanged(auth, setUser);
-    return () => unsub();
-  }, []);
-
-  useEffect(() => {
-    if (!user) return setEvents([]);
-
-    const now = new Date();
-    const ref = collection(db, "users", user.uid, "events");
-    const qref = query(
-      ref,
-      where("start", ">=", Timestamp.fromDate(now)),
-      orderBy("start", "asc"),
-      limit(50)
-    );
-
-    const unsub = onSnapshot(
-      qref,
-      (snap) => {
-        const rows = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
-        setEvents(rows);
-      },
-      (err) => {
-        console.error("Upcoming query failed", err);
-      }
-    );
-
-    return () => unsub();
-  }, [user]);
-
-  // Filter
   const visible = useMemo(() => {
     const now = new Date();
-    const text = search.trim().toLowerCase();
+    const query = search.trim().toLowerCase();
     const selected = selectedCalendarIds.length
       ? new Set(selectedCalendarIds)
       : null;
 
-    return events.filter((ev) => {
-      const calId = ev.calendarId || "main";
-      if (calendarFilter !== "all" && calId !== calendarFilter) return false;
-      if (selected.size > 0 && !selected.has(calId)) return false;
+    return events
+      .filter((event) => {
+        const start = event.start instanceof Date ? event.start : new Date(event.start);
+        if (start < now) return false;
 
-      if (text) {
-        const hay =
-          `${ev.summary || ""} ${ev.description || ""} ${ev.location || ""}`.toLowerCase();
-        if (!hay.includes(text)) return false;
-      }
-      return true;
-    });
+        const calendarId = event.calendarId || "main";
+        if (calendarFilter !== "all" && calendarId !== calendarFilter) return false;
+        if (selected && selected.size > 0 && !selected.has(calendarId)) return false;
+
+        if (query) {
+          const haystack = `${event.summary || ""} ${event.description || ""} ${
+            event.location || ""
+          }`.toLowerCase();
+          if (!haystack.includes(query)) return false;
+        }
+
+        return true;
+      })
+      .sort((a, b) => a.start - b.start)
+      .slice(0, MAX_RESULTS);
   }, [events, calendarFilter, search, selectedCalendarIds]);
 
-  if (!user) return <p className="text-gray-600 text-sm">Sign in to see upcoming.</p>;
-  if (visible.length === 0) return <p className="text-gray-600 text-sm">No upcoming items match.</p>;
+  if (visible.length === 0) {
+    return (
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        No upcoming items match the current filters.
+      </p>
+    );
+  }
 
   return (
-    <ul className="divide-y divide-gray-200">
-      {visible.map((ev) => {
-        const start = ev.start?.toDate?.() || new Date(ev.start);
-        const end = ev.end?.toDate?.();
-        const time = ev.allDay
-          ? "All day"
-          : `${start.toLocaleDateString()} ${start.toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}${end ? " – " + end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : ""}`;
-
-        return (
-          <li key={event.id} className="py-3 flex items-start justify-between gap-3">
-            <div>
-              <div className="font-medium text-gray-900">{ev.summary || "(no title)"}</div>
-              <div className="text-xs text-gray-500">{time}</div>
-              {ev.location && <div className="text-xs text-gray-500">📍 {ev.location}</div>}
+    <ul className="divide-y divide-gray-200 dark:divide-neutral-800">
+      {visible.map((event) => (
+        <li
+          key={event.id}
+          className="flex items-start justify-between gap-4 py-3"
+        >
+          <div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              {event.summary || "(no title)"}
             </div>
-            <div className="text-xs text-gray-500">{ev.calendarId || "main"}</div>
-          </li>
-        );
-      })}
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              {formatRange(event)}
+            </div>
+            {event.location && (
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                📍 {event.location}
+              </div>
+            )}
+          </div>
+          <div className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 dark:bg-neutral-900 dark:text-gray-300">
+            {event.calendarId || "main"}
+          </div>
+        </li>
+      ))}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- rewrite the todo list and upcoming widgets to consume the shared Lifehub data context and support filtering/search state
- rebuild the calendar day, month, and year views around the local demo data with richer rendering and calendar discovery hooks
- remove remaining Firebase imports so the app runs without missing dependencies

## Testing
- npm run lint
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d50d6e24a4832bb6f9a3245d2972f9